### PR TITLE
Fix invalid YAML in release-package workflow

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -160,10 +160,10 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ github.token }}
-          commit-message: chore(release): prepare ${{ inputs.release_version }}
+          commit-message: "chore(release): prepare ${{ inputs.release_version }}"
           branch: release-metadata/${{ inputs.release_version }}
           delete-branch: true
-          title: chore(release): prepare ${{ inputs.release_version }}
+          title: "chore(release): prepare ${{ inputs.release_version }}"
           body: |
             ## Summary
             - update release metadata for package version `${{ steps.create_package.outputs.package_version }}`


### PR DESCRIPTION
## Summary
- quote the `commit-message` value in the release workflow
- quote the `title` value in the release workflow

## Why
- GitHub rejects the workflow as invalid because those scalar values contain `:` and were left unquoted
- quoting them makes the workflow YAML valid without changing the intended behavior

## Testing
- validated with a local YAML parse
