### PR TITLE
docs: document grouped facet counts in commerce search

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,4 +145,6 @@ In the sample search experience, searching for `t-shirt` can show `Brand > Calvi
 
 This mismatch is not caused by missing query propagation in the LWC layer. Request traces for this repro show that the active query (`t-shirt`) is sent in both the main commerce `search` request and the commerce `facet?type=SEARCH` request.
 
-The most likely explanation is a grouped-count mismatch between parent product cards in the result list and variant or item-level facet counts returned by the Commerce platform. Before changing `commerceFacet`, `commerceCategoryFacet`, or `commerceInterface`, verify the example catalog product-grouping configuration in Coveo, especially the grouping field behavior and the `Use cache for nested queries` setting.
+The root cause in this case was the grouping field `ec_item_group_id` not having `Use cache for nested queries` enabled. After enabling that option on the facet field, the facet counts aligned correctly with the grouped commerce results.
+
+This lines up with documented `filterFacetCount` behavior in the Search API, where folded parent results can be excluded from facet count estimation only when the target folding field is also a facet field with `Use cache for nested queries` enabled. In Commerce API flows, this parameter is not exposed directly through CMH Facet Collections, but the grouped facet count behavior depends on the same field configuration.

--- a/README.md
+++ b/README.md
@@ -138,3 +138,11 @@ The fix I discovered elsewhere suggests that because tile menus can (or used to)
 
 I just ran into this again today when attempting to use a tile menu to display a menu within a new Experience (LWR) site and was stumped. In my testing even opening all the permissions for navigation items, the tile menus (and only tile menus) would not display to unauthenticated guest users until this permission was opened up.
 ```
+
+### Facet counts can differ from grouped search results
+
+In the sample search experience, searching for `t-shirt` can show `Brand > Calvin Klein (41)`. If you then search within the `Brand` facet for `Cal` and select `Calvin Klein`, the result list drops to 6 grouped products and the selected facet count becomes `Calvin Klein (6)`.
+
+This mismatch is not caused by missing query propagation in the LWC layer. Request traces for this repro show that the active query (`t-shirt`) is sent in both the main commerce `search` request and the commerce `facet?type=SEARCH` request.
+
+The most likely explanation is a grouped-count mismatch between parent product cards in the result list and variant or item-level facet counts returned by the Commerce platform. Before changing `commerceFacet`, `commerceCategoryFacet`, or `commerceInterface`, verify the example catalog product-grouping configuration in Coveo, especially the grouping field behavior and the `Use cache for nested queries` setting.


### PR DESCRIPTION
## Summary
- add a troubleshooting note to `README.md` for the grouped facet-count mismatch reproduced in this repo
- document the exact sample repro: search `t-shirt`, observe `Brand > Calvin Klein (41)`, then select `Calvin Klein` and observe 6 grouped results
- record the confirmed root cause and resolution so maintainers do not chase an LWC query-propagation fix

## Why
Issue #41 started from a suspicion that facet search was not receiving the active query context. Request traces from the sample site show that the active query (`t-shirt`) is already sent in both the commerce search request and the commerce facet-search request, so the mismatch is not caused by missing query propagation in this repository.

The confirmed root cause was the grouping field `ec_item_group_id` not having `Use cache for nested queries` enabled. After enabling that option on the facet field, the facet counts aligned correctly with the grouped commerce results.

This also matches the documented Search API `filterFacetCount` behavior: folded parent results are excluded from facet count estimation only when the target folding field is also a facet field with `Use cache for nested queries` enabled. In Commerce API flows, `filterFacetCount` is not exposed directly through CMH Facet Collections, but the grouped facet count behavior depends on the same field configuration.

## Maintainer impact
- gives maintainers a repo-local explanation of the mismatch before they change shared facet components
- records that the fix was a CMH field configuration update, not a JavaScript or static-resource change
- points future investigations toward grouping-field configuration first

## Validation
- reproduced on the sample site with the repo dataset
- confirmed the result summary shows 21 results for `t-shirt`
- confirmed the `Brand` facet shows `Calvin Klein (41)` before selection
- confirmed selecting `Calvin Klein` yields 6 grouped results
- confirmed both the commerce `search` request and the commerce `facet?type=SEARCH` request include `query: "t-shirt"`
- confirmed the count mismatch was resolved after enabling `Use cache for nested queries` on `ec_item_group_id`
- no automated tests were run because this PR only updates documentation

Closes #41
