### PR TITLE
feat: Added redirection trigger [#441906]

### DIFF
--- a/force-app/examples/main/lwc/exampleCommerceSearch/exampleCommerceSearch.html
+++ b/force-app/examples/main/lwc/exampleCommerceSearch/exampleCommerceSearch.html
@@ -38,6 +38,7 @@
           </div>
         </div>
       </div>
-    </div>  
+    </div>
+    <c-commerce-redirection-trigger engine-id={engineId}></c-commerce-redirection-trigger>
   </c-commerce-interface>
 </template>

--- a/force-app/main/default/lwc/commerceRedirectionTrigger/__tests__/commerceRedirectionTrigger.test.js
+++ b/force-app/main/default/lwc/commerceRedirectionTrigger/__tests__/commerceRedirectionTrigger.test.js
@@ -1,0 +1,156 @@
+/* eslint-disable jest/no-conditional-expect */
+/* eslint-disable no-import-assign */
+import CommerceRedirectionTrigger from "c/commerceRedirectionTrigger";
+// @ts-ignore
+import { createElement } from "lwc";
+import * as mockHeadlessLoader from "c/commerceHeadlessLoader";
+
+jest.mock("c/commerceHeadlessLoader");
+
+let isInitialized = false;
+let currentSubscribeCallback = null;
+const originalLocation = window.location;
+
+const exampleEngine = {
+  id: "exampleEngineId"
+};
+
+const mockUnsubscribe = jest.fn(() => {});
+
+const mockRedirectionTrigger = {
+  state: {},
+  subscribe: jest.fn((callback) => {
+    currentSubscribeCallback = callback;
+    callback();
+    return mockUnsubscribe;
+  })
+};
+
+const functionsMocks = {
+  buildRedirectionTrigger: jest.fn(() => mockRedirectionTrigger),
+  unsubscribe: mockUnsubscribe
+};
+
+const defaultOptions = {
+  engineId: exampleEngine.id
+};
+
+function createTestComponent(options = defaultOptions) {
+  prepareHeadlessState();
+
+  const element = createElement("c-commerce-redirection-trigger", {
+    is: CommerceRedirectionTrigger
+  });
+  for (const [key, value] of Object.entries(options)) {
+    element[key] = value;
+  }
+  document.body.appendChild(element);
+  return element;
+}
+
+function prepareHeadlessState() {
+  // @ts-ignore
+  mockHeadlessLoader.getHeadlessBundle = () => {
+    return {
+      buildRedirectionTrigger: functionsMocks.buildRedirectionTrigger
+    };
+  };
+}
+
+// Helper function to wait until the microtask queue is empty.
+function flushPromises() {
+  // eslint-disable-next-line @lwc/lwc/no-async-operation
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function mockSuccessfulHeadlessInitialization() {
+  // @ts-ignore
+  mockHeadlessLoader.initializeWithHeadless = (element, _, initialize) => {
+    if (element instanceof CommerceRedirectionTrigger && !isInitialized) {
+      isInitialized = true;
+      initialize(exampleEngine);
+    }
+  };
+}
+
+function cleanup() {
+  // The jsdom instance is shared across test cases in a single file so reset the DOM
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+  jest.clearAllMocks();
+  isInitialized = false;
+  currentSubscribeCallback = null;
+  mockRedirectionTrigger.state = {};
+}
+
+describe("c-commerce-redirection-trigger", () => {
+  beforeEach(() => {
+    mockSuccessfulHeadlessInitialization();
+
+    // Stub browser window redirection mechanics safely
+    delete window.location;
+    window.location = { replace: jest.fn() };
+  });
+
+  afterEach(() => {
+    cleanup();
+    window.location = originalLocation;
+  });
+
+  describe("controller initialization", () => {
+    it("should register the component for init and subscribe to state changes", async () => {
+      createTestComponent();
+      await flushPromises();
+
+      expect(mockHeadlessLoader.registerComponentForInit).toHaveBeenCalledTimes(
+        1
+      );
+      expect(functionsMocks.buildRedirectionTrigger).toHaveBeenCalledWith(
+        exampleEngine
+      );
+      expect(mockRedirectionTrigger.subscribe).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when redirection state updates", () => {
+    it("should not redirect if redirectTo property is absent", async () => {
+      mockRedirectionTrigger.state = { redirectTo: undefined };
+
+      createTestComponent();
+      await flushPromises();
+
+      // Fire subscriber updates manually to simulate context mutations
+      if (currentSubscribeCallback) {
+        currentSubscribeCallback();
+      }
+
+      expect(window.location.replace).not.toHaveBeenCalled();
+    });
+
+    it("should invoke window replacement if redirectTo is provided", async () => {
+      const redirectUrl = "https://example.com/target-destination";
+      mockRedirectionTrigger.state = { redirectTo: redirectUrl };
+
+      createTestComponent();
+      await flushPromises();
+
+      if (currentSubscribeCallback) {
+        currentSubscribeCallback();
+      }
+
+      expect(window.location.replace).toHaveBeenCalledWith(redirectUrl);
+    });
+  });
+
+  describe("disconnection handling", () => {
+    it("should cleanly unsubscribe when removed from DOM context", async () => {
+      const element = createTestComponent();
+      await flushPromises();
+
+      document.body.removeChild(element);
+
+      expect(functionsMocks.unsubscribe).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/force-app/main/default/lwc/commerceRedirectionTrigger/commerceRedirectionTrigger.js
+++ b/force-app/main/default/lwc/commerceRedirectionTrigger/commerceRedirectionTrigger.js
@@ -1,0 +1,73 @@
+// @ts-nocheck
+import {
+  getHeadlessBundle,
+  initializeWithHeadless,
+  registerComponentForInit
+} from "c/commerceHeadlessLoader";
+import { LightningElement, api } from "lwc";
+
+/** @typedef {import("coveo").CommerceEngine} CommerceEngine */
+/** @typedef {import("coveo").CoveoHeadlessCommerce} CoveoHeadlessCommerce */
+/** @typedef {import("coveo").RedirectionTrigger} RedirectionTrigger */
+
+/**
+ * The `CommerceRedirectionTrigger` component will redirect to the URL provided
+ * in the redirection trigger state, configured in the Coveo Administration Console.
+ * @category Utility
+ * @example
+ * <c-commerce-redirection-trigger engine-id={engineId}></c-commerce-redirection-trigger>
+ */
+export default class CommerceRedirectionTrigger extends LightningElement {
+  /**
+   * The ID of the engine instance the component registers to.
+   * @api
+   * @type {string}
+   */
+  @api engineId;
+
+  /** @type {CommerceEngine} */
+  engine;
+  /** @type {CoveoHeadlessCommerce} */
+  headless;
+  /** @type {RedirectionTrigger} */
+  redirectionTrigger;
+  /** @type {Function} */
+  unsubscribeRedirectionTrigger;
+
+  connectedCallback() {
+    registerComponentForInit(this, this.engineId);
+  }
+
+  renderedCallback() {
+    initializeWithHeadless(this, this.engineId, this.initialize);
+  }
+
+  disconnectedCallback() {
+    this.unsubscribeRedirectionTrigger?.();
+  }
+
+  /**
+   * @param {CommerceEngine} engine
+   */
+  initialize = (engine) => {
+    this.engine = engine;
+    this.headless = getHeadlessBundle(this.engineId);
+
+    this.redirectionTrigger = this.headless.buildRedirectionTrigger(
+      this.engine
+    );
+
+    this.unsubscribeRedirectionTrigger = this.redirectionTrigger.subscribe(() =>
+      this.updateState()
+    );
+  };
+
+  updateState() {
+    const state = this.redirectionTrigger?.state;
+
+    // Redirect to URL when provided in redirection trigger state.
+    if (state?.redirectTo) {
+      window.location.replace(state.redirectTo);
+    }
+  }
+}

--- a/force-app/main/default/lwc/commerceRedirectionTrigger/commerceRedirectionTrigger.js-meta.xml
+++ b/force-app/main/default/lwc/commerceRedirectionTrigger/commerceRedirectionTrigger.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>


### PR DESCRIPTION
[#441906: Enable query pipeline trigger redirect in the toolkit](https://dev.azure.com/CoveoPS/009%20-%20Methodology%20-%20Documentation%20-%20Tools%20and%20Processes/_workitems/edit/441906)

**Changelog**

- Created new `<c-commerce-redirection-trigger>` component to handle redirect triggers.
- Added component to `exampleCommerceSearch.html` page.
- Includes new unit tests.