### PR TITLE
[codex] Fix commerce search refresh and card spacing

### DIFF
--- a/force-app/main/default/lwc/commerceInterface/__tests__/commerceInterface.test.js
+++ b/force-app/main/default/lwc/commerceInterface/__tests__/commerceInterface.test.js
@@ -1,61 +1,144 @@
-import CommerceInterface from 'c/commerceInterface';
+import CommerceInterface from "c/commerceInterface";
+import { destroyEngine } from "c/commerceHeadlessLoader";
 
-describe('c-commerce-interface', () => {
-    let addEventListenerSpy;
+jest.mock("c/commerceHeadlessLoader", () => ({
+  getHeadlessBindings: jest.fn(),
+  loadDependencies: jest.fn(() => Promise.resolve()),
+  setEngineOptions: jest.fn(),
+  HeadlessBundleNames: {
+    commerce: "commerce"
+  },
+  destroyEngine: jest.fn(),
+  setInitializedCallback: jest.fn()
+}));
 
-    beforeEach(() => {
-        addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+describe("c-commerce-interface", () => {
+  let addEventListenerSpy;
+  let removeEventListenerSpy;
+
+  beforeEach(() => {
+    addEventListenerSpy = jest.spyOn(window, "addEventListener");
+    removeEventListenerSpy = jest.spyOn(window, "removeEventListener");
+  });
+
+  afterEach(() => {
+    addEventListenerSpy.mockRestore();
+    removeEventListenerSpy.mockRestore();
+    jest.clearAllMocks();
+    window.location.hash = "";
+  });
+
+  it("should initialize the URL manager when state in URL is enabled", () => {
+    const subscribe = jest.fn();
+    const urlManager = {
+      state: {
+        fragment: "q=box"
+      },
+      subscribe
+    };
+    const urlManagerFactory = jest.fn(() => urlManager);
+    const element = {
+      disableStateInUrl: false,
+      fragment: "q=box",
+      onHashChange: jest.fn(),
+      searchOrListing: {
+        urlManager: urlManagerFactory
+      }
+    };
+
+    CommerceInterface.prototype.initUrlManager.call(element);
+
+    expect(urlManagerFactory).toHaveBeenCalledWith({
+      initialState: { fragment: "q=box" }
+    });
+    expect(subscribe).toHaveBeenCalledTimes(1);
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      "hashchange",
+      element.onHashChange
+    );
+  });
+
+  it("should replace an existing URL manager subscription before reinitializing", () => {
+    const previousUnsubscribe = jest.fn();
+    const subscribe = jest.fn();
+    const urlManager = {
+      state: {
+        fragment: "q=box"
+      },
+      subscribe
+    };
+    const urlManagerFactory = jest.fn(() => urlManager);
+    const element = {
+      disableStateInUrl: false,
+      fragment: "q=box",
+      onHashChange: jest.fn(),
+      unsubscribeUrlManager: previousUnsubscribe,
+      searchOrListing: {
+        urlManager: urlManagerFactory
+      }
+    };
+
+    CommerceInterface.prototype.initUrlManager.call(element);
+
+    expect(previousUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "hashchange",
+      element.onHashChange
+    );
+    expect(urlManagerFactory).toHaveBeenCalledWith({
+      initialState: { fragment: "q=box" }
+    });
+  });
+
+  it("should not initialize the URL manager when state in URL is disabled", () => {
+    const urlManagerFactory = jest.fn();
+    const element = {
+      disableStateInUrl: true,
+      fragment: "q=box",
+      onHashChange: jest.fn(),
+      searchOrListing: {
+        urlManager: urlManagerFactory
+      }
+    };
+
+    CommerceInterface.prototype.initUrlManager.call(element);
+
+    expect(urlManagerFactory).not.toHaveBeenCalled();
+    expect(addEventListenerSpy).not.toHaveBeenCalled();
+  });
+
+  it("should execute the first search without redirect data on refreshed search pages", () => {
+    const executeFirstSearch = jest.fn();
+    const element = {
+      type: "search",
+      skipFirstSearch: false,
+      searchOrListing: {
+        executeFirstSearch
+      }
+    };
+
+    CommerceInterface.prototype.executeInitialRequest.call(element, {
+      dispatch: jest.fn()
     });
 
-    afterEach(() => {
-        addEventListenerSpy.mockRestore();
-        window.location.hash = '';
-    });
+    expect(executeFirstSearch).toHaveBeenCalledTimes(1);
+  });
 
-    it('should initialize the URL manager when state in URL is enabled', () => {
-        const subscribe = jest.fn();
-        const urlManager = {
-            state: {
-                fragment: 'q=box'
-            },
-            subscribe
-        };
-        const urlManagerFactory = jest.fn(() => urlManager);
-        const element = {
-            disableStateInUrl: false,
-            fragment: 'q=box',
-            onHashChange: jest.fn(),
-            searchOrListing: {
-                urlManager: urlManagerFactory
-            }
-        };
+  it("should tear down URL synchronization when disconnected", () => {
+    const unsubscribeUrlManager = jest.fn();
+    const element = {
+      engineId: "search-interface",
+      onHashChange: jest.fn(),
+      unsubscribeUrlManager
+    };
 
-        CommerceInterface.prototype.initUrlManager.call(element);
+    CommerceInterface.prototype.disconnectedCallback.call(element);
 
-        expect(urlManagerFactory).toHaveBeenCalledWith({
-            initialState: {fragment: 'q=box'}
-        });
-        expect(subscribe).toHaveBeenCalledTimes(1);
-        expect(addEventListenerSpy).toHaveBeenCalledWith(
-            'hashchange',
-            element.onHashChange
-        );
-    });
-
-    it('should not initialize the URL manager when state in URL is disabled', () => {
-        const urlManagerFactory = jest.fn();
-        const element = {
-            disableStateInUrl: true,
-            fragment: 'q=box',
-            onHashChange: jest.fn(),
-            searchOrListing: {
-                urlManager: urlManagerFactory
-            }
-        };
-
-        CommerceInterface.prototype.initUrlManager.call(element);
-
-        expect(urlManagerFactory).not.toHaveBeenCalled();
-        expect(addEventListenerSpy).not.toHaveBeenCalled();
-    });
+    expect(unsubscribeUrlManager).toHaveBeenCalledTimes(1);
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "hashchange",
+      element.onHashChange
+    );
+    expect(destroyEngine).toHaveBeenCalledWith("search-interface");
+  });
 });

--- a/force-app/main/default/lwc/commerceInterface/commerceInterface.js
+++ b/force-app/main/default/lwc/commerceInterface/commerceInterface.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 // @ts-ignore
-import getHeadlessConfiguration from '@salesforce/apex/CommerceController.getHeadlessConfiguration';
+import getHeadlessConfiguration from "@salesforce/apex/CommerceController.getHeadlessConfiguration";
 // @ts-ignore
 // import LOCALE from '@salesforce/i18n/locale';
 import {
@@ -9,10 +9,10 @@ import {
   setEngineOptions,
   HeadlessBundleNames,
   destroyEngine,
-  setInitializedCallback,
-} from 'c/commerceHeadlessLoader';
-import {STANDALONE_SEARCH_BOX_STORAGE_KEY} from 'c/commerceUtils';
-import {LightningElement, api} from 'lwc';
+  setInitializedCallback
+} from "c/commerceHeadlessLoader";
+import { STANDALONE_SEARCH_BOX_STORAGE_KEY } from "c/commerceUtils";
+import { LightningElement, api } from "lwc";
 
 /** @typedef {import("coveo").CommerceEngine} CommerceEngine */
 /** @typedef {import("coveo").CommerceEngineOptions} CommerceEngineOptions */
@@ -21,13 +21,13 @@ import {LightningElement, api} from 'lwc';
 /** @typedef {import("coveo").ProductListing} ProductListing */
 
 /**
-* The `CommerceInterface` component handles the headless commerce engine configuration.
-* A single instance should be used for each instance of the Coveo Headless commerce engine.
-* @fires CustomEvent#commerceInterfaceinitialized
-* @category Commerce
-* @example
-* <c-commerce-interface engine-id={engineId}></c-commerce-interface>
-*/
+ * The `CommerceInterface` component handles the headless commerce engine configuration.
+ * A single instance should be used for each instance of the Coveo Headless commerce engine.
+ * @fires CustomEvent#commerceInterfaceinitialized
+ * @category Commerce
+ * @example
+ * <c-commerce-interface engine-id={engineId}></c-commerce-interface>
+ */
 export default class CommerceInterface extends LightningElement {
   /**
    * The ID of the engine instance the component registers to.
@@ -54,21 +54,21 @@ export default class CommerceInterface extends LightningElement {
    * @api
    * @type {string}
    */
-  @api language = 'en';
+  @api language = "en";
 
   /**
    * The country to add in context for your Coveo-powered ecommerce site or application.
    * @api
    * @type {string}
    */
-  @api country = 'US';
+  @api country = "US";
 
   /**
    * The currency to add in context for your Coveo-powered ecommerce site or application.
    * @api
    * @type {string}
    */
-  @api currency = 'USD';
+  @api currency = "USD";
   /**
    * Whether to enable results (required for Spotlight Content).
    * @api
@@ -98,7 +98,7 @@ export default class CommerceInterface extends LightningElement {
    * @type {'search' | 'product-listing'}
    * @defaultValue 'search'
    */
-  @api type = 'search';
+  @api type = "search";
 
   /** @type {CommerceEngineOptions} */
   engineOptions;
@@ -116,6 +116,8 @@ export default class CommerceInterface extends LightningElement {
   ariaLiveEventsBound = false;
 
   disconnectedCallback() {
+    this.unsubscribeUrlManager?.();
+    window.removeEventListener("hashchange", this.onHashChange);
     destroyEngine(this.engineId);
   }
 
@@ -126,7 +128,8 @@ export default class CommerceInterface extends LightningElement {
           getHeadlessConfiguration()
             .then((data) => {
               if (data) {
-                const {organizationId, accessToken, ...rest} = JSON.parse(data);
+                const { organizationId, accessToken, ...rest } =
+                  JSON.parse(data);
                 this.engineOptions = {
                   configuration: {
                     organizationId,
@@ -142,8 +145,8 @@ export default class CommerceInterface extends LightningElement {
                         url: this.commerceUrl
                       }
                     },
-                    ...rest,
-                  },
+                    ...rest
+                  }
                 };
                 setEngineOptions(
                   this.engineOptions,
@@ -152,13 +155,13 @@ export default class CommerceInterface extends LightningElement {
                   this,
                   CoveoHeadlessCommerce
                 );
-                this.input.setAttribute('is-initialized', 'true');
+                this.input.setAttribute("is-initialized", "true");
                 setInitializedCallback(this.initialize, this.engineId);
               }
             })
             .catch((error) => {
               console.error(
-                'Error loading Headless endpoint configuration',
+                "Error loading Headless endpoint configuration",
                 error
               );
             });
@@ -167,7 +170,7 @@ export default class CommerceInterface extends LightningElement {
         }
       })
       .catch((error) => {
-        console.error('Error loading Headless dependencies', error);
+        console.error("Error loading Headless dependencies", error);
       });
   }
 
@@ -182,50 +185,55 @@ export default class CommerceInterface extends LightningElement {
     if (this.initialized) {
       return;
     }
-    
+
     this.initRequestStatus(engine);
     this.initContext(engine);
     // this.initLanguage();
     this.initUrlManager();
-   
-    // @ts-ignore
-    if (this.type === 'search') {
+    this.executeInitialRequest(engine);
 
-      if (!this.skipFirstSearch) {
-
-        const redirectData = window.localStorage.getItem(
-          STANDALONE_SEARCH_BOX_STORAGE_KEY
-        );
-
-        if (!redirectData) {
-          // @ts-ignore
-          this.searchOrListing.executeFirstSearch();
-          return 
-        }
-
-        window.localStorage.removeItem(STANDALONE_SEARCH_BOX_STORAGE_KEY);
-        const {value} = JSON.parse(redirectData);
-
-        engine.dispatch(CoveoHeadlessCommerce.loadQueryActions(engine).updateQuery({query: value}));
-        // @ts-ignore
-        this.searchOrListing.executeFirstSearch();
-      }
-    } else {
-      // @ts-ignore
-      this.searchOrListing.executeFirstRequest();
-    }
-    
     this.dispatchEvent(
       new CustomEvent(`commerceInterfaceinitialized`, {
         detail: {
           engineId: this.engineId
         },
         bubbles: true,
-        composed: true,
+        composed: true
       })
     );
     this.initialized = true;
   };
+
+  executeInitialRequest(engine) {
+    // @ts-ignore
+    if (this.type !== "search") {
+      // @ts-ignore
+      this.searchOrListing.executeFirstRequest();
+      return;
+    }
+
+    if (this.skipFirstSearch) {
+      return;
+    }
+
+    const redirectData = window.localStorage.getItem(
+      STANDALONE_SEARCH_BOX_STORAGE_KEY
+    );
+
+    if (redirectData) {
+      window.localStorage.removeItem(STANDALONE_SEARCH_BOX_STORAGE_KEY);
+      const { value } = JSON.parse(redirectData);
+
+      engine.dispatch(
+        CoveoHeadlessCommerce.loadQueryActions(engine).updateQuery({
+          query: value
+        })
+      );
+    }
+
+    // @ts-ignore
+    this.searchOrListing.executeFirstSearch();
+  }
 
   get fragment() {
     return window.location.hash.slice(1);
@@ -235,8 +243,12 @@ export default class CommerceInterface extends LightningElement {
     this.searchOrListing =
       // @ts-ignore
       this.type === "product-listing"
-        ? CoveoHeadlessCommerce.buildProductListing(engine, { enableResults: this.enableResults })
-        : CoveoHeadlessCommerce.buildSearch(engine, { enableResults: this.enableResults });
+        ? CoveoHeadlessCommerce.buildProductListing(engine, {
+            enableResults: this.enableResults
+          })
+        : CoveoHeadlessCommerce.buildSearch(engine, {
+            enableResults: this.enableResults
+          });
   }
 
   initContext(engine) {
@@ -249,20 +261,22 @@ export default class CommerceInterface extends LightningElement {
   //   }
   // }
 
-
   initUrlManager() {
     if (this.disableStateInUrl) {
       return;
     }
 
+    this.unsubscribeUrlManager?.();
+    window.removeEventListener("hashchange", this.onHashChange);
+
     this.urlManager = this.searchOrListing.urlManager({
-      initialState: {fragment: this.fragment},
+      initialState: { fragment: this.fragment }
     });
 
     this.unsubscribeUrlManager = this.urlManager.subscribe(() =>
       this.updateHash()
     );
-    window.addEventListener('hashchange', this.onHashChange);
+    window.addEventListener("hashchange", this.onHashChange);
   }
 
   updateHash() {
@@ -281,7 +295,6 @@ export default class CommerceInterface extends LightningElement {
    * @returns {HTMLInputElement}
    */
   get input() {
-    return this.template.querySelector('input');
+    return this.template.querySelector("input");
   }
-
 }

--- a/force-app/main/default/lwc/commerceProduct/__tests__/commerceProduct.test.js
+++ b/force-app/main/default/lwc/commerceProduct/__tests__/commerceProduct.test.js
@@ -1,102 +1,121 @@
-import { createElement } from 'lwc';
-import CommerceProduct from 'c/commerceProduct';
+import { createElement } from "lwc";
+import CommerceProduct from "c/commerceProduct";
 
-jest.mock('c/commerceHeadlessLoader', () => ({
-    getHeadlessEnginePromise: jest.fn().mockResolvedValue({}),
-    getHeadlessBundle: jest.fn().mockReturnValue({}),
-    registerComponentForInit: jest.fn(),
-    initializeWithHeadless: jest.fn(),
-    getHeadlessBindings: jest.fn().mockReturnValue({}),
-    getBueno: jest.fn().mockReturnValue(new Promise(() => {})),
-    loadDependencies: jest.fn().mockResolvedValue({}),
-    setInitializedCallback: jest.fn(),
-    setEngineOptions: jest.fn(),
-    setComponentInitialized: jest.fn(),
-    destroyEngine: jest.fn(),
-    registerToStore: jest.fn(),
-    getFromStore: jest.fn(),
-    registerSortOptionsToStore: jest.fn(),
-    getAllSortOptionsFromStore: jest.fn(),
-    getAllFacetsFromStore: jest.fn(),
-    isHeadlessBundle: jest.fn(),
-    HeadlessBundleNames: {},
+jest.mock("c/commerceHeadlessLoader", () => ({
+  getHeadlessEnginePromise: jest.fn().mockResolvedValue({}),
+  getHeadlessBundle: jest.fn().mockReturnValue({}),
+  registerComponentForInit: jest.fn(),
+  initializeWithHeadless: jest.fn(),
+  getHeadlessBindings: jest.fn().mockReturnValue({}),
+  getBueno: jest.fn().mockReturnValue(new Promise(() => {})),
+  loadDependencies: jest.fn().mockResolvedValue({}),
+  setInitializedCallback: jest.fn(),
+  setEngineOptions: jest.fn(),
+  setComponentInitialized: jest.fn(),
+  destroyEngine: jest.fn(),
+  registerToStore: jest.fn(),
+  getFromStore: jest.fn(),
+  registerSortOptionsToStore: jest.fn(),
+  getAllSortOptionsFromStore: jest.fn(),
+  getAllFacetsFromStore: jest.fn(),
+  isHeadlessBundle: jest.fn(),
+  HeadlessBundleNames: {}
 }));
 
-jest.mock('@salesforce/label/c.commerce_NavigateToRecord', () => ({ default: 'Navigate to Record' }), { virtual: true });
-jest.mock('@salesforce/label/c.commerce_OpensInBrowserTab', () => ({ default: 'Opens in Browser Tab' }), { virtual: true });
+jest.mock(
+  "@salesforce/label/c.commerce_NavigateToRecord",
+  () => ({ default: "Navigate to Record" }),
+  { virtual: true }
+);
+jest.mock(
+  "@salesforce/label/c.commerce_OpensInBrowserTab",
+  () => ({ default: "Opens in Browser Tab" }),
+  { virtual: true }
+);
 
 const mockProduct = {
-    permanentid: 'product-1',
-    ec_name: 'Test Product',
-    ec_thumbnails: ['https://example.com/image.jpg'],
-    clickUri: 'https://example.com/product',
-    children: [],
-    additionalFields: {},
+  permanentid: "product-1",
+  ec_name: "Test Product",
+  ec_thumbnails: ["https://example.com/image.jpg"],
+  clickUri: "https://example.com/product",
+  children: [],
+  additionalFields: {}
 };
 
-describe('c-commerce-product', () => {
-    afterEach(() => {
-        while (document.body.firstChild) {
-            document.body.removeChild(document.body.firstChild);
-        }
+describe("c-commerce-product", () => {
+  afterEach(() => {
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+  });
+
+  it("renders without errors when product prop is set", async () => {
+    const mockSelect = jest.fn();
+    const mockInteractiveProduct = jest
+      .fn()
+      .mockReturnValue({ select: mockSelect });
+
+    const element = createElement("c-commerce-product", {
+      is: CommerceProduct
     });
+    element.product = mockProduct;
+    element.interactiveProduct = mockInteractiveProduct;
+    document.body.appendChild(element);
 
-    it('renders without errors when product prop is set', async () => {
-        const mockSelect = jest.fn();
-        const mockInteractiveProduct = jest.fn().mockReturnValue({ select: mockSelect });
+    await Promise.resolve();
 
-        const element = createElement('c-commerce-product', {
-            is: CommerceProduct,
-        });
-        element.product = mockProduct;
-        element.interactiveProduct = mockInteractiveProduct;
-        document.body.appendChild(element);
+    expect(element).toBeTruthy();
+    const content = element.shadowRoot.querySelector(".product-item__content");
+    expect(content).toBeTruthy();
+    expect(content.classList.contains("slds-var-m-bottom_medium")).toBe(false);
+  });
 
-        await Promise.resolve();
+  it("calls interactiveProduct.select on right-click (contextmenu) on the product image", async () => {
+    const mockSelect = jest.fn();
+    const mockInteractiveProduct = jest
+      .fn()
+      .mockReturnValue({ select: mockSelect });
 
-        expect(element).toBeTruthy();
+    const element = createElement("c-commerce-product", {
+      is: CommerceProduct
     });
+    element.product = mockProduct;
+    element.interactiveProduct = mockInteractiveProduct;
+    document.body.appendChild(element);
 
-    it('calls interactiveProduct.select on right-click (contextmenu) on the product image', async () => {
-        const mockSelect = jest.fn();
-        const mockInteractiveProduct = jest.fn().mockReturnValue({ select: mockSelect });
+    await Promise.resolve();
 
-        const element = createElement('c-commerce-product', {
-            is: CommerceProduct,
-        });
-        element.product = mockProduct;
-        element.interactiveProduct = mockInteractiveProduct;
-        document.body.appendChild(element);
+    const img = element.shadowRoot.querySelector("img");
+    expect(img).toBeTruthy();
 
-        await Promise.resolve();
+    img.dispatchEvent(
+      new MouseEvent("contextmenu", { bubbles: true, cancelable: true })
+    );
 
-        const img = element.shadowRoot.querySelector('img');
-        expect(img).toBeTruthy();
-
-        img.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
-
-        expect(mockInteractiveProduct).toHaveBeenCalledWith({
-            options: {
-                product: expect.objectContaining({ permanentid: 'product-1' }),
-            },
-        });
-        expect(mockSelect).toHaveBeenCalledTimes(1);
+    expect(mockInteractiveProduct).toHaveBeenCalledWith({
+      options: {
+        product: expect.objectContaining({ permanentid: "product-1" })
+      }
     });
+    expect(mockSelect).toHaveBeenCalledTimes(1);
+  });
 
-    it('does not throw when interactiveProduct is not set on right-click', async () => {
-        const element = createElement('c-commerce-product', {
-            is: CommerceProduct,
-        });
-        element.product = mockProduct;
-        document.body.appendChild(element);
-
-        await Promise.resolve();
-
-        const img = element.shadowRoot.querySelector('img');
-        expect(img).toBeTruthy();
-
-        expect(() => {
-            img.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
-        }).not.toThrow();
+  it("does not throw when interactiveProduct is not set on right-click", async () => {
+    const element = createElement("c-commerce-product", {
+      is: CommerceProduct
     });
+    element.product = mockProduct;
+    document.body.appendChild(element);
+
+    await Promise.resolve();
+
+    const img = element.shadowRoot.querySelector("img");
+    expect(img).toBeTruthy();
+
+    expect(() => {
+      img.dispatchEvent(
+        new MouseEvent("contextmenu", { bubbles: true, cancelable: true })
+      );
+    }).not.toThrow();
+  });
 });

--- a/force-app/main/default/lwc/commerceProduct/commerceProduct.html
+++ b/force-app/main/default/lwc/commerceProduct/commerceProduct.html
@@ -1,5 +1,5 @@
 <template>
-  <div class="slds-theme_default slds-text-align_center slds-var-p-vertical_medium slds-var-m-bottom_medium product-item__content">
+  <div class="slds-theme_default slds-text-align_center slds-var-p-vertical_medium product-item__content">
     <c-commerce-product-template onclick={handleClick}>
         <div slot="badges" class="slds-grid slds-grid_vertical-align-center slds-var-m-vertical_xx-small slds-var-m-right_small">
           <div class="slds-var-m-right_xx-small">

--- a/force-app/main/default/lwc/commerceProductList/__tests__/commerceProductList.test.js
+++ b/force-app/main/default/lwc/commerceProductList/__tests__/commerceProductList.test.js
@@ -262,16 +262,21 @@ describe("c-commerce-product-list", () => {
       const element = createTestComponent({ enableResults: true });
       await flushPromises();
 
+      const productColumn = element.shadowRoot.querySelector(".slds-col");
       const productContainer = element.shadowRoot.querySelector(
         ".product-item__container"
       );
       const productComponent =
         productContainer?.querySelector("c-commerce-product");
 
-      expect(productContainer).toBeTruthy();
-      expect(productContainer.classList.contains("slds-var-m-bottom_medium")).toBe(
+      expect(productColumn).toBeTruthy();
+      expect(productColumn.classList.contains("slds-var-m-bottom_medium")).toBe(
         true
       );
+      expect(productContainer).toBeTruthy();
+      expect(
+        productContainer.classList.contains("slds-var-m-bottom_medium")
+      ).toBe(false);
       expect(productComponent).toBeTruthy();
     });
 
@@ -306,10 +311,19 @@ describe("c-commerce-product-list", () => {
       const spotlightComponents = element.shadowRoot.querySelectorAll(
         "c-commerce-spotlight-content"
       );
+      const spotlightContainer = spotlightComponents[0]?.parentElement;
       const productComponents =
         element.shadowRoot.querySelectorAll("c-commerce-product");
 
       expect(spotlightComponents.length).toBe(1);
+      expect(
+        spotlightContainer?.classList.contains("product-item__container")
+      ).toBe(true);
+      expect(
+        spotlightContainer?.classList.contains(
+          "product-item__spotlight-container"
+        )
+      ).toBe(true);
       expect(productComponents.length).toBe(1);
     });
 

--- a/force-app/main/default/lwc/commerceProductList/commerceProductList.css
+++ b/force-app/main/default/lwc/commerceProductList/commerceProductList.css
@@ -8,3 +8,11 @@
   box-shadow: 0px 10px 25px #e5e8e8;
   cursor: pointer;
 }
+
+.product-item__spotlight-container {
+  display: flex;
+}
+
+.product-item__spotlight-container c-commerce-spotlight-content {
+  flex: 1;
+}

--- a/force-app/main/default/lwc/commerceProductList/commerceProductList.html
+++ b/force-app/main/default/lwc/commerceProductList/commerceProductList.html
@@ -14,16 +14,20 @@
       <template for:each={products} for:item="product">
         <div
           key={product.key}
-          class="slds-col slds-size_1-of-1 slds-small-size_1-of-2 slds-medium-size_1-of-3 slds-large-size_1-of-4"
+          class="slds-col slds-var-m-bottom_medium slds-size_1-of-1 slds-small-size_1-of-2 slds-medium-size_1-of-3 slds-large-size_1-of-4"
         >
-          <c-commerce-spotlight-content
+          <div
             lwc:if={product.isResult}
-            result={product}
-            interactive-spotlight-content={product.interactiveSpotlightContent}
-          ></c-commerce-spotlight-content>
+            class="slds-box slds-theme_default product-item__container product-item__spotlight-container"
+          >
+            <c-commerce-spotlight-content
+              result={product}
+              interactive-spotlight-content={product.interactiveSpotlightContent}
+            ></c-commerce-spotlight-content>
+          </div>
           <div
             lwc:else
-            class="slds-box slds-theme_default slds-var-m-bottom_medium product-item__container"
+            class="slds-box slds-theme_default product-item__container"
           >
             <c-commerce-product
               product={product}

--- a/force-app/main/default/lwc/commerceSpotlightContent/commerceSpotlightContent.css
+++ b/force-app/main/default/lwc/commerceSpotlightContent/commerceSpotlightContent.css
@@ -10,6 +10,7 @@
 }
 
 .content__link {
+  flex: 1;
   position: relative;
   width: 100%;
   padding: 1rem;
@@ -24,7 +25,6 @@
 
 .content__link:hover {
   text-decoration: none;
-  box-shadow: 0px 10px 25px #e5e8e8;
   cursor: pointer;
 }
 

--- a/force-app/main/default/lwc/commerceSpotlightContent/commerceSpotlightContent.html
+++ b/force-app/main/default/lwc/commerceSpotlightContent/commerceSpotlightContent.html
@@ -1,6 +1,6 @@
 <template>
   <a
-    class="content__link slds-var-m-bottom_medium"
+    class="content__link"
     href={hrefValue}
     style={backgroundImage}
     onclick={handleClick}


### PR DESCRIPTION
## Summary
Fix the search-page refresh regression and normalize product-card spacing across standard and spotlight content cards.

## What Changed
- fixed `commerceInterface` so refreshed search pages complete initialization after the first search instead of bailing out early
- cleaned up URL-manager lifecycle teardown/reinit to avoid stale hash synchronization listeners stacking up
- moved row spacing responsibility to the outer product-grid item
- wrapped spotlight content cards in the same shared card container used by standard product cards
- removed redundant inner bottom spacing from standard product cards so both card types follow the same spacing model
- updated focused Jest coverage for the refresh path and card-layout regressions

## Root Cause
The search refresh bug came from `commerceInterface` returning immediately after `executeFirstSearch()` when no standalone-search redirect payload was present. That prevented full interface initialization on hard refresh and left the page in a fragile state where facets and search-box behavior could drift.

The layout inconsistency came from spacing being applied inside individual card implementations instead of at the shared grid-item level. Spotlight content and standard product cards were therefore using different box models.

## Impact
- search pages should keep facets and search-box state stable after browser refresh
- standard and spotlight cards should now align with a consistent outer frame and row spacing

## Validation
- `npx sfdx-lwc-jest --skipApiVersionCheck -- --runInBand force-app/main/default/lwc/commerceInterface/__tests__/commerceInterface.test.js`
- `npx sfdx-lwc-jest --skipApiVersionCheck -- --runInBand force-app/main/default/lwc/commerceProduct/__tests__/commerceProduct.test.js force-app/main/default/lwc/commerceProductList/__tests__/commerceProductList.test.js`
- `npx eslint force-app/main/default/lwc/commerceInterface/commerceInterface.js force-app/main/default/lwc/commerceInterface/__tests__/commerceInterface.test.js force-app/main/default/lwc/commerceProduct/__tests__/commerceProduct.test.js force-app/main/default/lwc/commerceProductList/__tests__/commerceProductList.test.js`

## Related Issues
- #69
- #70