### PR TITLE
feat: Enabled Spotlight Content with recent queries [#441063]

### DIFF
--- a/force-app/main/default/lwc/commerceProductList/commerceProductList.css
+++ b/force-app/main/default/lwc/commerceProductList/commerceProductList.css
@@ -10,7 +10,7 @@
 }
 
 .product-item__spotlight-container {
-  display: flex;
+  padding: 0;
 }
 
 .product-item__spotlight-container c-commerce-spotlight-content {

--- a/force-app/main/default/lwc/commerceSearchBox/commerceSearchBox.js
+++ b/force-app/main/default/lwc/commerceSearchBox/commerceSearchBox.js
@@ -159,6 +159,7 @@ export default class CommerceSearchBox extends LightningElement {
           queries: getItemFromLocalStorage(this.localStorageKey) ?? [],
         },
         options: {
+          enableResults: this.enableResults,
           maxLength: 100,
         },
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@coveo/bueno": "^1.1.8",
-        "@coveo/headless": "^3.51.5"
+        "@coveo/headless": "^3.52.0"
       },
       "devDependencies": {
         "@lwc/eslint-plugin-lwc": "^2.0.0",
@@ -999,9 +999,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@coveo/headless": {
-      "version": "3.51.5",
-      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-3.51.5.tgz",
-      "integrity": "sha512-UOpZFgfF3su0fFBiQHVepNK5CnmtLgTnjIlq5cm+q493OvimB3n7Zl9Yx4mrCv8WtJcVKqf3hc2LMuMAlqQ/RA==",
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-3.52.0.tgz",
+      "integrity": "sha512-9xUiIDq9cNCjgC/gJVmmQ/2TuYPuTVy1HfXQJaNF+8Apk5t81EEYx9wybOUnuQHknUcNWGou8OJ1Izc3wSgjXQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ag-ui/client": "0.0.53",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@coveo/bueno": "^1.1.8",
-    "@coveo/headless": "^3.51.5"
+    "@coveo/headless": "^3.52.0"
   },
   "engines": {
     "node": "^20.9.0 || ^22.11.0"


### PR DESCRIPTION
[#441063: Enable Spotlight Content on the lwc toolkit](https://dev.azure.com/CoveoPS/009%20-%20Methodology%20-%20Documentation%20-%20Tools%20and%20Processes/_workitems/edit/441063)

**Changelog**

- Enabled support for Spotlight Content with recent queries.
  - Updated Headless to [v3.52.0](https://github.com/coveo/ui-kit/blob/main/packages/headless/CHANGELOG.md#3520) which includes required fixes from [7810](https://github.com/coveo/ui-kit/pull/7810).
  - Added `enableResults` when using `buildRecentQueriesList`.
- Fixed Spotlight Content styling.